### PR TITLE
conf: support load conf with env

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -172,7 +172,7 @@ function load(confPath) {
         }
 
         function loadFolder(folderPath) {
-            var files = ralUtil.readdirSync(folderPath);
+            var files = ralUtil.readdirWithEnvSync(folderPath, ctx.env);
             files.map(loadFile);
         }
 
@@ -247,6 +247,14 @@ module.exports.getConf = function (name) {
         var conf = ralUtil.deepClone(config[name]);
         return conf;
     }
+};
+
+module.exports.clearConf = function () {
+    config = {};
+    rawConf = {};
+    updateNeededRawConf = {};
+    contextCache = {};
+    disableUpdate();
 };
 
 /**

--- a/lib/ctx.js
+++ b/lib/ctx.js
@@ -10,3 +10,4 @@
 module.exports.IDC_ALL = 'all';
 module.exports.currentIDC = module.exports.IDC_ALL; // default config update time is 60s
 module.exports.updateInterval = 60000;
+module.exports.env = process.env.RAL_ENV || process.env.YOG_ENV;

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,7 @@
 
 var _ = require('underscore');
 var fs = require('fs');
+var p = require('path');
 var util = module.exports;
 
 util.merge = function (source, target) {
@@ -57,4 +58,72 @@ util.readdirSync = function (dir) {
         }
     });
     return results;
+};
+
+util.readdirWithEnvSync = function (path, prefer) {
+    var loaded = {};
+    var files = [];
+    util.readdirSync(path).forEach(function (subPath) {
+        if (loaded[p.normalize(subPath)]) {
+            return;
+        }
+        var ext = p.extname(subPath);
+        var filePath = null;
+        var basename = p.basename(subPath, ext);
+        var subfix = p.extname(basename);
+        var dirname = p.dirname(subPath);
+        var confname = p.basename(basename, subfix);
+        var confID = dirname + '/' + p.basename(basename, subfix) + '@' + prefer;
+        if (basename[0] === '.' || loaded[confID]) {
+            return;
+        }
+
+        function getPreferFile() {
+            // check if prefer file is exist
+            if (prefer) {
+                var preferFile = dirname + p.sep + confname + '.' + prefer + ext;
+                if (fs.existsSync(preferFile)) {
+                    return preferFile;
+                }
+            }
+            return false;
+        }
+
+        if (subfix === prefer) {
+            // load orgin file if subfix == prefer
+            filePath = subPath;
+        }
+        else {
+            var preferFile = getPreferFile();
+            if (preferFile) {
+                // load prefer file if prefer file is exist
+                filePath = preferFile;
+            }
+            else if (subfix === '.default') {
+                // load xxx.default.js only if xxx.js (normalName) is not exist
+                var normalName = dirname + p.sep + p.basename(basename, subfix) + ext;
+                if (fs.existsSync(normalName)) {
+                    filePath = normalName;
+                }
+                else {
+                    // load default file if normal file is not exist
+                    filePath = subPath;
+                }
+            }
+            else if (subfix === '') {
+                filePath = subPath;
+            }
+        }
+        if (filePath) {
+            filePath = p.normalize(filePath);
+            if (loaded[filePath]) {
+                return;
+            }
+            // 记录confID与filePath均被处理用于减少查询操作
+            loaded[filePath] = true;
+            loaded[confID] = true;
+            files.push(filePath);
+        }
+    });
+    return files;
 };

--- a/test/config.js
+++ b/test/config.js
@@ -117,4 +117,62 @@ describe('load config', function () {
         confs.should.containEql('bookService', 'bookServiceBNS', 'bookListService', 'bookListServiceWithCUI');
         ctx.currentIDC.should.be.equal('tc');
     });
+
+    it('load with env undefined', function () {
+        config.clearConf();
+        var origin = ctx.env;
+        ctx.env = undefined;
+        config.load(path.join(__dirname, './config/envconfig'));
+        ctx.env = origin;
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e');
+        config.getConf('a').query.name.should.equal('normal');
+        config.getConf('b').query.name.should.equal('normal');
+        config.getConf('c').query.name.should.equal('default');
+        config.getConf('d').query.name.should.equal('normal');
+        config.getConf('e').query.name.should.equal('normal');
+    });
+
+    it('load with env prod', function () {
+        config.clearConf();
+        var origin = ctx.env;
+        ctx.env = 'prod';
+        config.load(path.join(__dirname, './config/envconfig'));
+        ctx.env = origin;
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e');
+        config.getConf('a').query.name.should.equal('normal');
+        config.getConf('b').query.name.should.equal('normal');
+        config.getConf('c').query.name.should.equal('default');
+        config.getConf('d').query.name.should.equal('normal');
+        config.getConf('e').query.name.should.equal('prod');
+    });
+
+    it('load with env kk', function () {
+        config.clearConf();
+        var origin = ctx.env;
+        ctx.env = 'kk';
+        config.load(path.join(__dirname, './config/envconfig'));
+        ctx.env = origin;
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e');
+        config.getConf('a').query.name.should.equal('kk');
+        config.getConf('b').query.name.should.equal('normal');
+        config.getConf('c').query.name.should.equal('default');
+        config.getConf('d').query.name.should.equal('normal');
+        config.getConf('e').query.name.should.equal('normal');
+    });
+
+
+    it('load with env dev', function () {
+        config.clearConf();
+        var origin = ctx.env;
+        ctx.env = 'dev';
+        config.load(path.join(__dirname, './config/envconfig'));
+        ctx.env = origin;
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e', 'f');
+        config.getConf('a').query.name.should.equal('dev');
+        config.getConf('b').query.name.should.equal('normal');
+        config.getConf('c').query.name.should.equal('default');
+        config.getConf('d').query.name.should.equal('normal');
+        config.getConf('e').query.name.should.equal('normal');
+        config.getConf('f').query.name.should.equal('dev');
+    });
 });

--- a/test/config.js
+++ b/test/config.js
@@ -124,12 +124,13 @@ describe('load config', function () {
         ctx.env = undefined;
         config.load(path.join(__dirname, './config/envconfig'));
         ctx.env = origin;
-        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e');
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e', 'g');
         config.getConf('a').query.name.should.equal('normal');
         config.getConf('b').query.name.should.equal('normal');
         config.getConf('c').query.name.should.equal('default');
         config.getConf('d').query.name.should.equal('normal');
         config.getConf('e').query.name.should.equal('normal');
+        config.getConf('g').query.name.should.equal('default');
     });
 
     it('load with env prod', function () {
@@ -138,12 +139,13 @@ describe('load config', function () {
         ctx.env = 'prod';
         config.load(path.join(__dirname, './config/envconfig'));
         ctx.env = origin;
-        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e');
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e', 'g');
         config.getConf('a').query.name.should.equal('normal');
         config.getConf('b').query.name.should.equal('normal');
         config.getConf('c').query.name.should.equal('default');
         config.getConf('d').query.name.should.equal('normal');
         config.getConf('e').query.name.should.equal('prod');
+        config.getConf('g').query.name.should.equal('default');
     });
 
     it('load with env kk', function () {
@@ -152,12 +154,13 @@ describe('load config', function () {
         ctx.env = 'kk';
         config.load(path.join(__dirname, './config/envconfig'));
         ctx.env = origin;
-        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e');
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e', 'g');
         config.getConf('a').query.name.should.equal('kk');
         config.getConf('b').query.name.should.equal('normal');
         config.getConf('c').query.name.should.equal('default');
         config.getConf('d').query.name.should.equal('normal');
         config.getConf('e').query.name.should.equal('normal');
+        config.getConf('g').query.name.should.equal('default');
     });
 
 
@@ -167,12 +170,13 @@ describe('load config', function () {
         ctx.env = 'dev';
         config.load(path.join(__dirname, './config/envconfig'));
         ctx.env = origin;
-        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e', 'f');
+        config.getRawConf().should.have.keys('a', 'b', 'c', 'd', 'e', 'f', 'g');
         config.getConf('a').query.name.should.equal('dev');
         config.getConf('b').query.name.should.equal('normal');
         config.getConf('c').query.name.should.equal('default');
         config.getConf('d').query.name.should.equal('normal');
         config.getConf('e').query.name.should.equal('normal');
         config.getConf('f').query.name.should.equal('dev');
+        config.getConf('g').query.name.should.equal('dev');
     });
 });

--- a/test/config/envconfig/a.default.js
+++ b/test/config/envconfig/a.default.js
@@ -1,0 +1,17 @@
+module.exports = {
+    a: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'default'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/a.dev.js
+++ b/test/config/envconfig/a.dev.js
@@ -1,0 +1,17 @@
+module.exports = {
+    a: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'dev'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/a.js
+++ b/test/config/envconfig/a.js
@@ -1,0 +1,17 @@
+module.exports = {
+    a: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'normal'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/a.kk.js
+++ b/test/config/envconfig/a.kk.js
@@ -1,0 +1,17 @@
+module.exports = {
+    a: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'kk'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/b.default.js
+++ b/test/config/envconfig/b.default.js
@@ -1,0 +1,17 @@
+module.exports = {
+    b: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'default'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/b.js
+++ b/test/config/envconfig/b.js
@@ -1,0 +1,17 @@
+module.exports = {
+    b: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'normal'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/c.default.js
+++ b/test/config/envconfig/c.default.js
@@ -1,0 +1,17 @@
+module.exports = {
+    c: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'default'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/d.js
+++ b/test/config/envconfig/d.js
@@ -1,0 +1,17 @@
+module.exports = {
+    d: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'normal'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/nested/e.js
+++ b/test/config/envconfig/nested/e.js
@@ -1,0 +1,17 @@
+module.exports = {
+    e: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'normal'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/nested/e.prod.js
+++ b/test/config/envconfig/nested/e.prod.js
@@ -1,0 +1,17 @@
+module.exports = {
+    e: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'prod'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/nested/f.dev.js
+++ b/test/config/envconfig/nested/f.dev.js
@@ -1,0 +1,17 @@
+module.exports = {
+    f: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'dev'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/nested/g.default.js
+++ b/test/config/envconfig/nested/g.default.js
@@ -1,0 +1,17 @@
+module.exports = {
+    g: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'default'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};

--- a/test/config/envconfig/nested/g.dev.js
+++ b/test/config/envconfig/nested/g.dev.js
@@ -1,0 +1,17 @@
+module.exports = {
+    g: {
+        unpack: 'json',
+        pack: 'json',
+        encoding: 'GBK',
+        balance: 'random',
+        protocol: 'http',
+        query: {
+            name: 'dev'
+        },
+        server: [{
+            host: 'st.yd.baidu.com',
+            port: 80,
+            idc: 'st'
+        }]
+    }
+};


### PR DESCRIPTION
https://github.com/fex-team/yog2/issues/53

通过YOG_ENV或RAL_ENV配置可以使node-ral在加载配置文件夹时，会使用环境变量进行加载

举例来说

当 YOG_ENV=dev 时，在如下情况下，会加载 a.dev.js 与 b.js
```
- a.dev.js
- a.js
- b.js
```

当 YOG_ENV=prod 时，在如下情况下，只加载 a.js, b.js, c.prod.js
```
- a.dev.js
- a.js
- b.js
- c.prod.js
- d.dev.js
```

当 YOG_ENV=undefined 时，在如下情况下，只加载 a.js, b.js
```
- a.dev.js
- a.js
- b.js
- c.prod.js
- d.dev.js
```