### PR TITLE
fix #143 多service共用同一个配置对象

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -179,6 +179,9 @@ function load(confPath) {
             if (ext === '.js') {
                 logger.trace('load config from ' + filePath);
                 data = require(filePath);
+                if (data) {
+                    data = ralUtil.deepClone(data);
+                }
             }
             else if (ext === '.json') {
                 logger.trace('load config from ' + filePath);


### PR DESCRIPTION
rawConf似乎在其他地方也有用到，所以在load时直接用了deepClone