### PR TITLE
Support multiple Redis servers connection with auth

### DIFF
--- a/lib/ext/protocol/redisProtocol.js
+++ b/lib/ext/protocol/redisProtocol.js
@@ -43,6 +43,7 @@ RedisProtocol.prototype.normalizeConfig = RedisProtocol.normalizeConfig = functi
 RedisProtocol.prototype.createClient = function(config) {
     config.redisConf.host = config.server.host;
     config.redisConf.port = config.server.port;
+    config.redisConf.password = config.server.password;
     var configKey = this.getConfigKey(config);
     var client;
     if (!clientCache[configKey] || config.noClientCache) {


### PR DESCRIPTION
// When using multiple redis connections with auth, we want to support the following configuration.
const redisConfig = {
    protocol: 'redis',
    pack: 'redis',
    unpack: 'redis',
    balance: 'random',
    protocol: 'redis',
    server:[
        {
            host: '10.x.x.1.',
            port: 8379,
            password: '123abc'
        },
        {
            host: '10.x.x.2,
            port: 8379,
            password: 'abc123'
        },
       ...more
    ]
};