### PR TITLE
perf: logger 信息前缀名称由 options.app 指定

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -30,14 +30,14 @@ module.exports = function (prefix) {
                 return;
             }
             var content = Array.prototype.slice.call(arguments, 0).join('');
-            options.logInstance(options).notice('[yog-ral] ' + prefix + content);
+            options.logInstance(options).notice(`[${options.app}] ` + prefix + content);
         },
         warning: function (msg) {
             if (options.disable) {
                 return;
             }
             var content = Array.prototype.slice.call(arguments, 0).join('');
-            options.logInstance(options).warning('[yog-ral] ' + prefix + content);
+            options.logInstance(options).warning(`[${options.app}] ` + prefix + content);
         },
 
         fatal: function (msg) {
@@ -45,7 +45,7 @@ module.exports = function (prefix) {
                 return;
             }
             var content = Array.prototype.slice.call(arguments, 0).join('');
-            options.logInstance(options).fatal('[yog-ral] ' + prefix + content);
+            options.logInstance(options).fatal(`[${options.app}] ` + prefix + content);
         },
 
         trace: function () {
@@ -53,7 +53,7 @@ module.exports = function (prefix) {
                 return;
             }
             var content = Array.prototype.slice.call(arguments, 0).join('');
-            options.logInstance(options).trace('[yog-ral] ' + prefix + content);
+            options.logInstance(options).trace(`[${options.app}] ` + prefix + content);
         },
 
         debug: function (msg) {
@@ -61,7 +61,7 @@ module.exports = function (prefix) {
                 return;
             }
             var content = Array.prototype.slice.call(arguments, 0).join('');
-            options.logInstance(options).debug('[yog-ral] ' + prefix + content);
+            options.logInstance(options).debug(`[${options.app}] ` + prefix + content);
         }
     };
 };


### PR DESCRIPTION
问题：
Kob 想基于 node-ral 开发 Kob-ral 插件，发现内置的 logger 组件 log 的 message 添加了默认的 [yog-ral] 前缀
解决：
希望通过配置指定前缀名称